### PR TITLE
Fix broken PR (Permissions. Add run.sh)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,8 @@
 FROM debian:buster-slim
-MAINTAINER wekan
+LABEL maintainer="wekan"
 
 # Declare Arguments
+ARG DEBUG
 ARG NODE_VERSION
 ARG METEOR_RELEASE
 ARG METEOR_EDGE
@@ -17,14 +18,75 @@ ARG MATOMO_DO_NOT_TRACK
 ARG MATOMO_WITH_USERNAME
 ARG BROWSER_POLICY_ENABLED
 ARG TRUSTED_URL
+ARG WEBHOOKS_ATTRIBUTES
+ARG OAUTH2_ENABLED
+ARG OAUTH2_CLIENT_ID
+ARG OAUTH2_SECRET
+ARG OAUTH2_SERVER_URL
+ARG OAUTH2_AUTH_ENDPOINT
+ARG OAUTH2_USERINFO_ENDPOINT
+ARG OAUTH2_TOKEN_ENDPOINT
+ARG OAUTH2_ID_MAP
+ARG OAUTH2_USERNAME_MAP
+ARG OAUTH2_FULLNAME_MAP
+ARG OAUTH2_EMAIL_MAP
+ARG OAUTH2_ID_TOKEN_WHITELIST_FIELDS
+ARG OAUTH2_REQUEST_PERMISSIONS
+ARG LDAP_ENABLE
+ARG LDAP_PORT
+ARG LDAP_HOST
+ARG LDAP_BASEDN
+ARG LDAP_LOGIN_FALLBACK
+ARG LDAP_RECONNECT
+ARG LDAP_TIMEOUT
+ARG LDAP_IDLE_TIMEOUT
+ARG LDAP_CONNECT_TIMEOUT
+ARG LDAP_AUTHENTIFICATION
+ARG LDAP_AUTHENTIFICATION_USERDN
+ARG LDAP_AUTHENTIFICATION_PASSWORD
+ARG LDAP_LOG_ENABLED
+ARG LDAP_BACKGROUND_SYNC
+ARG LDAP_BACKGROUND_SYNC_INTERVAL
+ARG LDAP_BACKGROUND_SYNC_KEEP_EXISTANT_USERS_UPDATED
+ARG LDAP_BACKGROUND_SYNC_IMPORT_NEW_USERS
+ARG LDAP_ENCRYPTION
+ARG LDAP_CA_CERT
+ARG LDAP_REJECT_UNAUTHORIZED
+ARG LDAP_USER_SEARCH_FILTER
+ARG LDAP_USER_SEARCH_SCOPE
+ARG LDAP_USER_SEARCH_FIELD
+ARG LDAP_SEARCH_PAGE_SIZE
+ARG LDAP_SEARCH_SIZE_LIMIT
+ARG LDAP_GROUP_FILTER_ENABLE
+ARG LDAP_GROUP_FILTER_OBJECTCLASS
+ARG LDAP_GROUP_FILTER_GROUP_ID_ATTRIBUTE
+ARG LDAP_GROUP_FILTER_GROUP_MEMBER_ATTRIBUTE
+ARG LDAP_GROUP_FILTER_GROUP_MEMBER_FORMAT
+ARG LDAP_GROUP_FILTER_GROUP_NAME
+ARG LDAP_UNIQUE_IDENTIFIER_FIELD
+ARG LDAP_UTF8_NAMES_SLUGIFY
+ARG LDAP_USERNAME_FIELD
+ARG LDAP_FULLNAME_FIELD
+ARG LDAP_MERGE_EXISTING_USERS
+ARG LDAP_SYNC_USER_DATA
+ARG LDAP_SYNC_USER_DATA_FIELDMAP
+ARG LDAP_SYNC_GROUP_ROLES
+ARG LDAP_DEFAULT_DOMAIN
+ARG LOGOUT_WITH_TIMER
+ARG LOGOUT_IN
+ARG LOGOUT_ON_HOURS
+ARG LOGOUT_ON_MINUTES
+ARG CORS
+ARG DEFAULT_AUTHENTICATION_METHOD
 ARG WEKAN_UID
 ARG WEKAN_GID
 
 # Set the environment variables (defaults where required)
 # DOES NOT WORK: paxctl fix for alpine linux: https://github.com/wekan/wekan/issues/1303
 # ENV BUILD_DEPS="paxctl"
-ENV BUILD_DEPS="apt-utils gnupg gosu wget curl bzip2 build-essential python git ca-certificates gcc-7" \
-    NODE_VERSION=v8.12.0 \
+ENV BUILD_DEPS="apt-utils bsdtar gnupg gosu wget curl bzip2 build-essential python python3 python3-distutils git ca-certificates gcc-7" \
+    DEBUG=false \
+    NODE_VERSION=v8.15.0 \
     METEOR_RELEASE=1.6.0.1 \
     USE_EDGE=false \
     METEOR_EDGE=1.5-beta.17 \
@@ -38,9 +100,70 @@ ENV BUILD_DEPS="apt-utils gnupg gosu wget curl bzip2 build-essential python git 
     MATOMO_DO_NOT_TRACK=true \
     MATOMO_WITH_USERNAME=false \
     BROWSER_POLICY_ENABLED=true \
-    TRUSTED_URL=""
+    TRUSTED_URL="" \
+    WEBHOOKS_ATTRIBUTES="" \
+    OAUTH2_ENABLED=false \
+    OAUTH2_CLIENT_ID="" \
+    OAUTH2_SECRET="" \
+    OAUTH2_SERVER_URL="" \
+    OAUTH2_AUTH_ENDPOINT="" \
+    OAUTH2_USERINFO_ENDPOINT="" \
+    OAUTH2_TOKEN_ENDPOINT="" \
+    OAUTH2_ID_MAP="" \
+    OAUTH2_USERNAME_MAP="" \
+    OAUTH2_FULLNAME_MAP="" \
+    OAUTH2_EMAIL_MAP="" \
+    OAUTH2_ID_TOKEN_WHITELIST_FIELDS=[] \
+    OAUTH2_REQUEST_PERMISSIONS=[openid] \
+    LDAP_ENABLE=false \
+    LDAP_PORT=389 \
+    LDAP_HOST="" \
+    LDAP_BASEDN="" \
+    LDAP_LOGIN_FALLBACK=false \
+    LDAP_RECONNECT=true \
+    LDAP_TIMEOUT=10000 \
+    LDAP_IDLE_TIMEOUT=10000 \
+    LDAP_CONNECT_TIMEOUT=10000 \
+    LDAP_AUTHENTIFICATION=false \
+    LDAP_AUTHENTIFICATION_USERDN="" \
+    LDAP_AUTHENTIFICATION_PASSWORD="" \
+    LDAP_LOG_ENABLED=false \
+    LDAP_BACKGROUND_SYNC=false \
+    LDAP_BACKGROUND_SYNC_INTERVAL=100 \
+    LDAP_BACKGROUND_SYNC_KEEP_EXISTANT_USERS_UPDATED=false \
+    LDAP_BACKGROUND_SYNC_IMPORT_NEW_USERS=false \
+    LDAP_ENCRYPTION=false \
+    LDAP_CA_CERT="" \
+    LDAP_REJECT_UNAUTHORIZED=false \
+    LDAP_USER_SEARCH_FILTER="" \
+    LDAP_USER_SEARCH_SCOPE="" \
+    LDAP_USER_SEARCH_FIELD="" \
+    LDAP_SEARCH_PAGE_SIZE=0 \
+    LDAP_SEARCH_SIZE_LIMIT=0 \
+    LDAP_GROUP_FILTER_ENABLE=false \
+    LDAP_GROUP_FILTER_OBJECTCLASS="" \
+    LDAP_GROUP_FILTER_GROUP_ID_ATTRIBUTE="" \
+    LDAP_GROUP_FILTER_GROUP_MEMBER_ATTRIBUTE="" \
+    LDAP_GROUP_FILTER_GROUP_MEMBER_FORMAT="" \
+    LDAP_GROUP_FILTER_GROUP_NAME="" \
+    LDAP_UNIQUE_IDENTIFIER_FIELD="" \
+    LDAP_UTF8_NAMES_SLUGIFY=true \
+    LDAP_USERNAME_FIELD="" \
+    LDAP_FULLNAME_FIELD="" \
+    LDAP_MERGE_EXISTING_USERS=false \
+    LDAP_SYNC_USER_DATA=false \
+    LDAP_SYNC_USER_DATA_FIELDMAP="" \
+    LDAP_SYNC_GROUP_ROLES="" \
+    LDAP_DEFAULT_DOMAIN="" \
+    LOGOUT_WITH_TIMER=false \
+    LOGOUT_IN="" \
+    LOGOUT_ON_HOURS="" \
+    LOGOUT_ON_MINUTES="" \
+    CORS="" \
+    DEFAULT_AUTHENTICATION_METHOD=""
 
 RUN \
+    set -o xtrace && \
     # Add non-root user wekan
     groupadd -g ${WEKAN_GID} wekan && \
     useradd --system -m -u ${WEKAN_UID} -g ${WEKAN_GID} wekan && \
@@ -49,22 +172,14 @@ RUN \
     # OS dependencies
     apt-get update -y && apt-get install -y --no-install-recommends ${BUILD_DEPS} && \
     \
-    # Download nodejs
-    #wget https://nodejs.org/dist/${NODE_VERSION}/node-${NODE_VERSION}-${ARCHITECTURE}.tar.gz && \
-    #wget https://nodejs.org/dist/${NODE_VERSION}/SHASUMS256.txt.asc && \
-    #---------------------------------------------------------------------------------------------
-    # Node Fibers 100% CPU usage issue:
-    # https://github.com/wekan/wekan-mongodb/issues/2#issuecomment-381453161
-    # https://github.com/meteor/meteor/issues/9796#issuecomment-381676326
-    # https://github.com/sandstorm-io/sandstorm/blob/0f1fec013fe7208ed0fd97eb88b31b77e3c61f42/shell/server/00-startup.js#L99-L129
-    # Also see beginning of wekan/server/authentication.js
-    #   import Fiber from "fibers";
-    #   Fiber.poolSize = 1e9;
-    # Download node version 8.12.0 prerelease that has fix included,
-    # Description at https://releases.wekan.team/node.txt
-    wget https://releases.wekan.team/node-${NODE_VERSION}-${ARCHITECTURE}.tar.gz && \
-    echo "1ed54adb8497ad8967075a0b5d03dd5d0a502be43d4a4d84e5af489c613d7795  node-v8.12.0-linux-x64.tar.gz" >> SHASUMS256.txt.asc && \
+    # Meteor installer doesn't work with the default tar binary, so using bsdtar while installing.
+    # https://github.com/coreos/bugs/issues/1095#issuecomment-350574389
+    cp $(which tar) $(which tar)~ && \
+    ln -sf $(which bsdtar) $(which tar) && \
     \
+    # Download nodejs
+    wget https://nodejs.org/dist/${NODE_VERSION}/node-${NODE_VERSION}-${ARCHITECTURE}.tar.gz && \
+    wget https://nodejs.org/dist/${NODE_VERSION}/SHASUMS256.txt.asc && \
     # Verify nodejs authenticity
     grep ${NODE_VERSION}-${ARCHITECTURE}.tar.gz SHASUMS256.txt.asc | shasum -a 256 -c - && \
     rm -f SHASUMS256.txt.asc && \
@@ -91,12 +206,20 @@ COPY \
     src/.meteor/versions \
     /home/wekan/app/.meteor/
 
+COPY \
+    src/fix-download-unicode/cfs_access-point.txt \
+    /home/wekan/app/fix-download-unicode/cfs_access-point.txt
+
+COPY \
+    src/package.json \
+    /home/wekan/app/package.json
+
 RUN \
     # Change user to wekan and install meteor
     cd /home/wekan/ && \
     chown wekan:wekan --recursive /home/wekan && \
-    curl https://install.meteor.com -o /home/wekan/install_meteor.sh && \
-    sed -i "s|RELEASE=.*|RELEASE=${METEOR_RELEASE}\"\"|g" ./install_meteor.sh && \
+    curl "https://install.meteor.com" -o /home/wekan/install_meteor.sh && \
+    sed -i 's/VERBOSITY="--silent"/VERBOSITY="--progress-bar"/' ./install_meteor.sh && \
     echo "Starting meteor ${METEOR_RELEASE} installation...   \n" && \
     chown wekan:wekan /home/wekan/install_meteor.sh && \
     \
@@ -105,17 +228,22 @@ RUN \
       gosu wekan:wekan sh /home/wekan/install_meteor.sh; \
     else \
       gosu wekan:wekan git clone --recursive --depth 1 -b release/METEOR@${METEOR_EDGE} git://github.com/meteor/meteor.git /home/wekan/.meteor; \
-    fi; \
-    \
+    fi;
+
+RUN \
     # Get additional packages
     mkdir -p /home/wekan/app/packages && \
     chown wekan:wekan --recursive /home/wekan && \
     cd /home/wekan/app/packages && \
     gosu wekan:wekan git clone --depth 1 -b master git://github.com/wekan/flow-router.git kadira-flow-router && \
     gosu wekan:wekan git clone --depth 1 -b master git://github.com/meteor-useraccounts/core.git meteor-useraccounts-core && \
+    gosu wekan:wekan git clone --depth 1 -b master git://github.com/wekan/meteor-accounts-cas.git && \
+    gosu wekan:wekan git clone --depth 1 -b master git://github.com/wekan/wekan-ldap.git && \
+    gosu wekan:wekan git clone --depth 1 -b master git://github.com/wekan/wekan-scrollbar.git && \
     sed -i 's/api\.versionsFrom/\/\/api.versionsFrom/' /home/wekan/app/packages/meteor-useraccounts-core/package.js && \
     cd /home/wekan/.meteor && \
-    gosu wekan:wekan /home/wekan/.meteor/meteor --help
+    gosu wekan:wekan /home/wekan/.meteor/meteor -- help;
+    # We dont need openapi
 
 RUN \
     # Build app
@@ -123,9 +251,13 @@ RUN \
     gosu wekan:wekan /home/wekan/.meteor/meteor add standard-minifier-js && \
     gosu wekan:wekan /home/wekan/.meteor/meteor npm install && \
     gosu wekan:wekan /home/wekan/.meteor/meteor build --directory /home/wekan/app_build && \
+    cp /home/wekan/app/fix-download-unicode/cfs_access-point.txt /home/wekan/app_build/bundle/programs/server/packages/cfs_access-point.js && \
     chown wekan:wekan /home/wekan/app_build/bundle/programs/server/packages/cfs_access-point.js && \
     cd /home/wekan/app_build/bundle/programs/server/ && \
-    gosu wekan:wekan npm install
+    gosu wekan:wekan npm install && \
+    \
+    # Put back the original tar
+    mv $(which tar)~ $(which tar)
     # Cleanup
    # apt-get remove --purge -y ${BUILD_DEPS} && \
    # apt-get autoremove -y && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,20 +10,35 @@ ARG NPM_VERSION
 ARG FIBERS_VERSION
 ARG ARCHITECTURE
 ARG SRC_PATH
+ARG WITH_API
+ARG MATOMO_ADDRESS
+ARG MATOMO_SITE_ID
+ARG MATOMO_DO_NOT_TRACK
+ARG MATOMO_WITH_USERNAME
+ARG BROWSER_POLICY_ENABLED
+ARG TRUSTED_URL
 ARG WEKAN_UID
 ARG WEKAN_GID
 
 # Set the environment variables (defaults where required)
-# paxctl fix for alpine linux: https://github.com/wekan/wekan/issues/1303
-ENV BUILD_DEPS="apt-utils gnupg gosu wget curl bzip2 build-essential python git ca-certificates gcc-7 paxctl"
-ENV NODE_VERSION ${NODE_VERSION:-v8.9.3}
-ENV METEOR_RELEASE ${METEOR_RELEASE:-1.6.0.1}
-ENV USE_EDGE ${USE_EDGE:-false}
-ENV METEOR_EDGE ${METEOR_EDGE:-1.5-beta.17}
-ENV NPM_VERSION ${NPM_VERSION:-5.5.1}
-ENV FIBERS_VERSION ${FIBERS_VERSION:-2.0.0}
-ENV ARCHITECTURE ${ARCHITECTURE:-linux-x64}
-ENV SRC_PATH ${SRC_PATH:-./}
+# DOES NOT WORK: paxctl fix for alpine linux: https://github.com/wekan/wekan/issues/1303
+# ENV BUILD_DEPS="paxctl"
+ENV BUILD_DEPS="apt-utils gnupg gosu wget curl bzip2 build-essential python git ca-certificates gcc-7" \
+    NODE_VERSION=v8.12.0 \
+    METEOR_RELEASE=1.6.0.1 \
+    USE_EDGE=false \
+    METEOR_EDGE=1.5-beta.17 \
+    NPM_VERSION=latest \
+    FIBERS_VERSION=2.0.0 \
+    ARCHITECTURE=linux-x64 \
+    SRC_PATH=./src/ \
+    WITH_API=true \
+    MATOMO_ADDRESS="" \
+    MATOMO_SITE_ID="" \
+    MATOMO_DO_NOT_TRACK=true \
+    MATOMO_WITH_USERNAME=false \
+    BROWSER_POLICY_ENABLED=true \
+    TRUSTED_URL=""
 
 RUN \
     # Add non-root user wekan
@@ -35,34 +50,23 @@ RUN \
     apt-get update -y && apt-get install -y --no-install-recommends ${BUILD_DEPS} && \
     \
     # Download nodejs
-    wget https://nodejs.org/dist/${NODE_VERSION}/node-${NODE_VERSION}-${ARCHITECTURE}.tar.gz && \
-    wget https://nodejs.org/dist/${NODE_VERSION}/SHASUMS256.txt.asc && \
+    #wget https://nodejs.org/dist/${NODE_VERSION}/node-${NODE_VERSION}-${ARCHITECTURE}.tar.gz && \
+    #wget https://nodejs.org/dist/${NODE_VERSION}/SHASUMS256.txt.asc && \
+    #---------------------------------------------------------------------------------------------
+    # Node Fibers 100% CPU usage issue:
+    # https://github.com/wekan/wekan-mongodb/issues/2#issuecomment-381453161
+    # https://github.com/meteor/meteor/issues/9796#issuecomment-381676326
+    # https://github.com/sandstorm-io/sandstorm/blob/0f1fec013fe7208ed0fd97eb88b31b77e3c61f42/shell/server/00-startup.js#L99-L129
+    # Also see beginning of wekan/server/authentication.js
+    #   import Fiber from "fibers";
+    #   Fiber.poolSize = 1e9;
+    # Download node version 8.12.0 prerelease that has fix included,
+    # Description at https://releases.wekan.team/node.txt
+    wget https://releases.wekan.team/node-${NODE_VERSION}-${ARCHITECTURE}.tar.gz && \
+    echo "1ed54adb8497ad8967075a0b5d03dd5d0a502be43d4a4d84e5af489c613d7795  node-v8.12.0-linux-x64.tar.gz" >> SHASUMS256.txt.asc && \
     \
     # Verify nodejs authenticity
     grep ${NODE_VERSION}-${ARCHITECTURE}.tar.gz SHASUMS256.txt.asc | shasum -a 256 -c - && \
-    export GNUPGHOME="$(mktemp -d)" && \
-    \
-    # Try other key servers if ha.pool.sks-keyservers.net is unreachable
-    # Code from https://github.com/chorrell/docker-node/commit/2b673e17547c34f17f24553db02beefbac98d23c
-    # gpg keys listed at https://github.com/nodejs/node#release-team
-    # and keys listed here from previous version of this Dockerfile
-    for key in \
-    9554F04D7259F04124DE6B476D5A82AC7E37093B \
-    94AE36675C464D64BAFA68DD7434390BDBE9B9C5 \
-    FD3A5288F042B6850C66B31F09FE44734EB7990E \
-    71DCFD284A79C3B38668286BC97EC7A07EDE3FC1 \
-    DD8F2338BAE7501E3DD5AC78C273792F7D83545D \
-    C4F0DFFF4E8C1A8236409D08E73BC641CC11F4C8 \
-    B9AE9905FFD7803F25714661B63B535A4C206CA9 \
-    ; do \
-    gpg --keyserver ha.pool.sks-keyservers.net --recv-keys "$key" || \
-    gpg --keyserver pgp.mit.edu --recv-keys "$key" || \
-    gpg --keyserver keyserver.pgp.com --recv-keys "$key" ; \
-    done && \
-    gpg --verify SHASUMS256.txt.asc && \
-    # Ignore socket files then delete files then delete directories
-    find "$GNUPGHOME" -type f | xargs rm -f && \
-    find "$GNUPGHOME" -type d | xargs rm -fR && \
     rm -f SHASUMS256.txt.asc && \
     \
     # Install Node
@@ -71,9 +75,6 @@ RUN \
     mv node-${NODE_VERSION}-${ARCHITECTURE} /opt/nodejs && \
     ln -s /opt/nodejs/bin/node /usr/bin/node && \
     ln -s /opt/nodejs/bin/npm /usr/bin/npm && \
-    \
-    # paxctl fix for alpine linux: https://github.com/wekan/wekan/issues/1303
-    paxctl -mC `which node` && \
     \
     # Install Node dependencies
     npm install -g npm@${NPM_VERSION} && \
@@ -90,36 +91,50 @@ COPY \
     src/.meteor/versions \
     /home/wekan/app/.meteor/
 
-RUN chown -R wekan:wekan /home/wekan
-
-USER wekan
-
 RUN \
+    # Change user to wekan and install meteor
     cd /home/wekan/ && \
+    chown wekan:wekan --recursive /home/wekan && \
     curl https://install.meteor.com -o /home/wekan/install_meteor.sh && \
-    sed -i "s|RELEASE=.*|RELEASE=${METEOR_RELEASE}\"\"|g" /home/wekan/install_meteor.sh && \
+    sed -i "s|RELEASE=.*|RELEASE=${METEOR_RELEASE}\"\"|g" ./install_meteor.sh && \
     echo "Starting meteor ${METEOR_RELEASE} installation...   \n" && \
+    chown wekan:wekan /home/wekan/install_meteor.sh && \
     \
     # Check if opting for a release candidate instead of major release
     if [ "$USE_EDGE" = false ]; then \
-      /bin/bash /home/wekan/install_meteor.sh; \
+      gosu wekan:wekan sh /home/wekan/install_meteor.sh; \
     else \
-      clone --recursive --depth 1 -b release/METEOR@${METEOR_EDGE} git://github.com/meteor/meteor.git /home/wekan/.meteor; \
+      gosu wekan:wekan git clone --recursive --depth 1 -b release/METEOR@${METEOR_EDGE} git://github.com/meteor/meteor.git /home/wekan/.meteor; \
     fi; \
     \
     # Get additional packages
     mkdir -p /home/wekan/app/packages && \
+    chown wekan:wekan --recursive /home/wekan && \
     cd /home/wekan/app/packages && \
-    git clone --depth 1 -b master git://github.com/wekan/flow-router.git kadira-flow-router && \
-    git clone --depth 1 -b master git://github.com/meteor-useraccounts/core.git meteor-useraccounts-core && \
+    gosu wekan:wekan git clone --depth 1 -b master git://github.com/wekan/flow-router.git kadira-flow-router && \
+    gosu wekan:wekan git clone --depth 1 -b master git://github.com/meteor-useraccounts/core.git meteor-useraccounts-core && \
     sed -i 's/api\.versionsFrom/\/\/api.versionsFrom/' /home/wekan/app/packages/meteor-useraccounts-core/package.js && \
     cd /home/wekan/.meteor && \
-    /home/wekan/.meteor/meteor -- help;
+    gosu wekan:wekan /home/wekan/.meteor/meteor --help
 
-WORKDIR /home/wekan/app
-RUN /home/wekan/.meteor/meteor build --directory /home/wekan/app_build
+RUN \
+    # Build app
+    cd /home/wekan/app && \
+    gosu wekan:wekan /home/wekan/.meteor/meteor add standard-minifier-js && \
+    gosu wekan:wekan /home/wekan/.meteor/meteor npm install && \
+    gosu wekan:wekan /home/wekan/.meteor/meteor build --directory /home/wekan/app_build && \
+    chown wekan:wekan /home/wekan/app_build/bundle/programs/server/packages/cfs_access-point.js && \
+    cd /home/wekan/app_build/bundle/programs/server/ && \
+    gosu wekan:wekan npm install
+    # Cleanup
+   # apt-get remove --purge -y ${BUILD_DEPS} && \
+   # apt-get autoremove -y && \
+   # rm -R /var/lib/apt/lists/* && \
+   # rm /home/wekan/install_meteor.sh
 
 ENV PORT=3000
 EXPOSE $PORT
+USER wekan
+WORKDIR /home/wekan/app
 
 CMD ["/home/wekan/.meteor/meteor", "run", "--verbose"]

--- a/README.md
+++ b/README.md
@@ -8,11 +8,10 @@ To get started, you'll need [Docker](https://www.docker.com/products/docker) set
 Then:
 
 ```
-git clone https://github.com/wekan/wekan-dev.git wekan
-cd wekan
+git clone https://github.com/wekan/wekan-dev.git wekan-dev
+cd wekan-dev
 git submodule update --init --remote
-(cd src; npm install)
-docker-compose up --build -d
+./run.sh
 ```
 
 This will take some time to build the image, and to initially cache & build the meteor packages.

--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+sudo WEKAN_UID="$(id -u)" WEKAN_GID="$(id -g)" docker-compose build

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -32,6 +32,9 @@ services:
     environment:
       - MONGO_URL=mongodb://wekandb-dev:27017/wekan
       - ROOT_URL=http://localhost:8081
+      - WITH_API=true
+      - BROWSER_POLICY_ENABLED=true
+      - TRUSTED_URL=''
     depends_on:
       - wekandb-dev
     volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,6 +24,9 @@ services:
     build:
       context: .
       dockerfile: Dockerfile
+      args:
+        - WEKAN_UID=${WEKAN_UID}
+        - WEKAN_GID=${WEKAN_GID}
     ports:
       - 8081:3000
     environment:

--- a/run.sh
+++ b/run.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-sudo WEKAN_UID="$(id -u)" WEKAN_GID="$(id -g)" docker-compose up -d --build
+sudo WEKAN_UID="$(id -u)" WEKAN_GID="$(id -g)" docker-compose up -d

--- a/run.sh
+++ b/run.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+sudo WEKAN_UID="$(id -u)" WEKAN_GID="$(id -g)" docker-compose up -d --build


### PR DESCRIPTION
My last PR actually broke the repo, sorry about that :'( I was running somehow an old image.

I added a script (`run.sh`) to start the services and creating the container user with the same UID and GID of the host user. This way everything can be installed and downloaded with user `wekan` in the Dockerfile.

I switched back to port 3000, as port 80 isn't correct apparently.

I tested the whole build process and works well. The only caveat is that after the first run, there's a sym link in `src/.meteor/local/build/programs/server`:

```
node_modules -> /home/wekan/.meteor/packages/meteor-tool/.1.6.0_1.obe9u1++os.linux.x86_64+web.browser+web.cordova/mt-os.linux.x86_64/dev_bundle/server-lib/node_modules
```
This gives an `IOError` unless you use docker-compose 1.20.0 (I tested with latest 1.20.0-rc2).

I also added correction of README pointed out by #5 

Can someone try these changes? Thanks!