### PR TITLE
Adding SSO CAS to Wekan

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -100,6 +100,8 @@ RUN \
     cd /home/wekan/app/packages && \
     gosu wekan:wekan git clone --depth 1 -b master git://github.com/wekan/flow-router.git kadira-flow-router && \
     gosu wekan:wekan git clone --depth 1 -b master git://github.com/meteor-useraccounts/core.git meteor-useraccounts-core && \
+    # adding CAS
+    gosu wekan:wekan git clone --depth 1 -b master git://github.com/atoy40/meteor-accounts-cas.git atoy40-meteor-accounts-cas && \
     sed -i 's/api\.versionsFrom/\/\/api.versionsFrom/' /home/wekan/app/packages/meteor-useraccounts-core/package.js && \
     cd /home/wekan/.meteor && \
     gosu wekan:wekan /home/wekan/.meteor/meteor -- help;
@@ -125,4 +127,4 @@ ENV PORT=80
 EXPOSE $PORT
 
 USER wekan
-CMD ["/home/wekan/.meteor/meteor", "run", "--verbose"]
+CMD ["/home/wekan/.meteor/meteor", "run", "--verbose", "--settings", "settings.json"]


### PR DESCRIPTION
This is the integration to Wekan of the package atoy40:meteor-account-cas.
See https://github.com/wekan/wekan/issues/620
There is also a change in wekan build project : https://github.com/wekan/wekan/pull/1742

Usage: 
-without settings, CAS is disabled
-the presence of the settings indicated here https://atmospherejs.com/atoy40/accounts-cas will activate CAS ; don't forget to specify the ROOT_URL properly 
