### PR TITLE
fixed link in readme for local dev environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ docker-compose up --build -d
 ```
 
 This will take some time to build the image, and to initially cache & build the meteor packages.
-Eventually you should be able to see Wekan at `http://localhost:3000/`, and changes made under
+Eventually you should be able to see Wekan at [`http://localhost/`](http://localhost/), and changes made under
 `src/` will automatically trigger a refresh of the interface. Note that the `src/` directory also
 includes docker configuration; those are for the production builds of Wekan.
 


### PR DESCRIPTION
The application can be seen at http://localhost (http://localhost:80) instead of http://localhost:3000
It first confused me, because the build succeeded and everything looked fine, but it seemed that the application did not start correctly.
Correct documentation always helps :-)